### PR TITLE
Add snap package. https://snapcraft.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check-for-update": "^1.0.3",
     "classnames": "^2.2.5",
     "electron": "^1.4.1",
-    "electron-builder": "^10.17.3",
+    "electron-builder": "^19.50.0",
     "envify": "^4.0.0",
     "flux": "^3.0.0",
     "gulp": "^3.9.1",
@@ -63,7 +63,14 @@
         "deb",
         "rpm",
         "freebsd",
-        "zip"
+        "zip",
+        "snap"
+      ]
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "desktop"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check-for-update": "^1.0.3",
     "classnames": "^2.2.5",
     "electron": "^1.4.1",
-    "electron-builder": "^19.50.0",
+    "electron-builder": "^19.53.0",
     "envify": "^4.0.0",
     "flux": "^3.0.0",
     "gulp": "^3.9.1",
@@ -65,12 +65,6 @@
         "freebsd",
         "zip",
         "snap"
-      ]
-    },
-    "snap": {
-      "plugs": [
-        "default",
-        "desktop"
       ]
     }
   },


### PR DESCRIPTION
I've put together this pull request to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 18.04 (daily) and 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist` on an Ubuntu 16.04 VM with an [appropriate version of node installed](https://github.com/nodesource/distributions) it will create `dist/donut_2.4.0_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous donut_2.4.0_amd64.snap`. Execute it with `donut` from the terminal or find it in the desktop launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "donut" name](https://dashboard.snapcraft.io/register-snap/?name=donut).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push it to the store out with:
`snapcraft push donut_2.4.0_amd64.snap --release stable`

(You can also push to the Snap Store [programatically from Travis](https://gist.github.com/evandandrea/c754964bfdfb176844f26f605ebbb8db).)